### PR TITLE
Change to a Markdown ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,29 +77,29 @@ feed without interfering with the feed result:
 There are a few key differences between the way one uses
 objects from Sum:: versus the Perl 5 Digest:: interface.
 
-1) Use .push, not ->add to add elements to the Sum.
+1. Use .push, not ->add to add elements to the Sum.
    There is an .add method but its exact behavior changes
    with the algorithm and the backend.  Only use .add
    directly when optimizing for site-specific use cases.
 
-2) Use .finalize, not ->digest.  This change makes it clearer
+2. Use .finalize, not ->digest.  This change makes it clearer
    that the calculation is complete and (in most algorithms)
    more addends cannot be pushed to the digest.  This also
    brings Perl 6 in line with the prevalent vernacular.
 
-3) While it is possible (and easy) to build a Sum class that will
+3. While it is possible (and easy) to build a Sum class that will
    take strings as arguments to .push, it is more advisable
    to keep decisions about encoding visible at the point
    of use.  Consider this behavior of Perl 5 Digest:: when
    you encounter characters with ordinal values between
    129 and 255:
 
-      use Digest::SHA sha1_base64;
-      use Encode qw(encode_utf8);
-      say sha1_base64(encode_utf8('here is a french brace »'));
-      # S+YAQNtj1tluLgYewYgoWvdrSgQ
-      say sha1_base64(            'here is a french brace »')";
-      # 5hoNlI0QihTToOzKPc8pdMwEhWM
+        use Digest::SHA sha1_base64;
+        use Encode qw(encode_utf8);
+        say sha1_base64(encode_utf8('here is a french brace »'));
+        # S+YAQNtj1tluLgYewYgoWvdrSgQ
+        say sha1_base64(            'here is a french brace »')";
+        # 5hoNlI0QihTToOzKPc8pdMwEhWM
 
    However, in Perl 5 you MUST use encode_utf8 if you handle any
    characters with ordinals above 255.  There is too much opportunity
@@ -112,9 +112,9 @@ objects from Sum:: versus the Perl 5 Digest:: interface.
 
    Fortunately, encoding is a built-in capability of Perl 6:
 
-      $sha.push('here is a french brace »'.encode('utf8'));
+        $sha.push('here is a french brace »'.encode('utf8'));
 
-4) Note that the return value of .finalize is the finalized
+4. Note that the return value of .finalize is the finalized
    Sum object.  This can be coerced to common types you might
    want using and formatted using many built-in Perl 6
    methods.  Also, .finalize takes arguments, which are just
@@ -126,25 +126,25 @@ objects from Sum:: versus the Perl 5 Digest:: interface.
    There are some shortcuts built in, which also have the
    benefit of including leading zeros.
 
-       say mysha.new.finalize($buffer).fmt(); # lowercase hex (e.g. sha1_hex)
-       say mysha.new.finalize($buffer).fmt("%2.2x",":"); # colon octets
-       say mysha.new.finalize($buffer).base(16); # uppercase hex
-       say mysha.new.finalize($buffer).base(2);  # binary text
+        say mysha.new.finalize($buffer).fmt(); # lowercase hex (e.g. sha1_hex)
+        say mysha.new.finalize($buffer).fmt("%2.2x",":"); # colon octets
+        say mysha.new.finalize($buffer).base(16); # uppercase hex
+        say mysha.new.finalize($buffer).base(2);  # binary text
 
-5) There is no ->reset method, and .new does not re-use
+5. There is no ->reset method, and .new does not re-use
    the Perl 6 object when called on an instance, it just
    creates a new Perl 6 object.  Sum objects are meant
    to be thrown away after use.  Replacing them is easy:
 
-      # assuming $md has a Sum in it, or was constrained when defined.
-      $md .= new;
+        # assuming $md has a Sum in it, or was constrained when defined.
+        $md .= new;
 
    If you are concerned about tying up crypto resources, the
    only thing to worry about is to ensure you finalize the object
    before discarding it.  The backends should be smart enough to
    free up resources promptly upon finalization.
 
-6) Just about everything in perl 6 has a .clone method,
+6. Just about everything in perl 6 has a .clone method,
    including Sum objects.  However, not all back-ends
    can clone their instances.  Using a class that does
    Sum::Partial is one way to guarantee that only backends


### PR DESCRIPTION
Using `1)` instead of `1.` is a common error when writing Markdown. ( It elludes me to as to why so many people make this mistake )

Also indents should always be multiples of 4 spaces.
I didn't change this as it  messes with `git blame`.
I would increase the indents from 3 spaces to 4 spaces, as the individual lines get edited.